### PR TITLE
increased tasks intervals to 5 minutes from 30 seconds

### DIFF
--- a/base/celery.py
+++ b/base/celery.py
@@ -16,14 +16,14 @@ app.autodiscover_tasks()
 app.conf.beat_schedule = {
     "update-blockchain-metrics": {
         "task": "blockchain.tasks.update_blockchain_metrics",
-        "schedule": 30.0,
+        "schedule": 300.0, # Increased to 5 minutes
     },
     "process_garden_updates": {
         "task": "garden.tasks.process_garden_updates",
-        "schedule": 30.0,
+        "schedule": 300.0,
     },
     "monitor_user_activities": {
         "task": "blockchain.tasks.monitor_user_activities",
-        "schedule": 30.0,
+        "schedule": 300.0,
     },
 }

--- a/base/celery.py
+++ b/base/celery.py
@@ -20,10 +20,10 @@ app.conf.beat_schedule = {
     },
     "process_garden_updates": {
         "task": "garden.tasks.process_garden_updates",
-        "schedule": 300.0,
+        "schedule": 350.0,
     },
     "monitor_user_activities": {
         "task": "blockchain.tasks.monitor_user_activities",
-        "schedule": 300.0,
+        "schedule": 400.0,
     },
 }


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Increase the execution interval of the `update-blockchain-metrics`, `process_garden_updates`, and `monitor_user_activities` tasks from 30 seconds to 5 minutes.